### PR TITLE
about initialized of __path__

### DIFF
--- a/tutorial/modules.po
+++ b/tutorial/modules.po
@@ -659,8 +659,8 @@ msgid ""
 "This variable can be modified; doing so affects future searches for modules "
 "and subpackages contained in the package."
 msgstr ""
-"包还支持特殊属性 :attr:`__path__`。该属性初始化为在包的 :file:`__init__.py` "
-"文件中的代码执行前所在的目录名列表。这个变量可以修改，但这样做会影响将来搜索包中模块和子包的操作。"
+"包还支持特殊属性 :attr:`__path__`。在包的 :file:`__init__.py` 文件中的代码被执行前，"
+"该属性被初始化为包含 :file:`__init__.py` 文件所在的目录名在内的列表。这个变量可以修改，但这样做会影响将来搜索包中模块和子包的操作。"
 
 #: ../../tutorial/modules.rst:568
 msgid ""


### PR DESCRIPTION
This is initialized to be a list containing the name of the directory holding the package’s __init__.py before the code in that file is executed
原翻译：该属性初始化为在包的 __init__.py 文件中的代码执行前所在的目录名列表。
新翻译：在包的 :file:`__init__.py` 文件中的代码被执行前，"
"该属性被初始化为包含 :file:`__init__.py` 文件所在的目录名在内的列表。