### PR TITLE
修正C扩展接口翻译问题

### DIFF
--- a/extending/extending.po
+++ b/extending/extending.po
@@ -70,7 +70,7 @@ msgid ""
 msgstr ""
 "C扩展接口特指CPython，扩展模块无法在其他Python实现上工作。在大多数情况下，应该避免写C扩展，来保持可移植性。举个例子，如果你的用例调用了C库或系统调用，你应该考虑使用"
 " :mod:`ctypes` 模块或 `cffi <https://cffi.readthedocs.io/>`_ "
-"库，而不是自己写C代码。这些模块允许你写Python代码来接口C代码，而且可移植性更好。不知为何编译失败了。"
+"库，而不是自己写C代码。这些模块允许你写Python代码来接口C代码，并且相较于编写和编译C扩展模块，该方法在不同Python实现之间具有更高的可移植性。"
 
 #: ../../extending/extending.rst:40
 msgid "A Simple Example"


### PR DESCRIPTION
*Python3.13 使用 C 或 C++ 扩展 Python* 部分文档（/extending/extending.po）存在翻译错误与冗余内容。

修改如下：
- 删除了原文中“不知为何编译失败了”的错误内容。
- 修改翻译，使其与英文原文一致，强调ctypes 模块或 cffi 库的特性。