### PR TITLE
ci: declare workflow-level `contents: read` on the 9 python-N.yml build workflows

### DIFF
--- a/.github/workflows/python-310.yml
+++ b/.github/workflows/python-310.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "22 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-311.yml
+++ b/.github/workflows/python-311.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "32 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-312.yml
+++ b/.github/workflows/python-312.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "42 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-313.yml
+++ b/.github/workflows/python-313.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "52 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-314.yml
+++ b/.github/workflows/python-314.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "2 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-315.yml
+++ b/.github/workflows/python-315.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "12 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-37.yml
+++ b/.github/workflows/python-37.yml
@@ -2,6 +2,9 @@ name: python-37
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-38.yml
+++ b/.github/workflows/python-38.yml
@@ -2,6 +2,9 @@ name: python-38
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml

--- a/.github/workflows/python-39.yml
+++ b/.github/workflows/python-39.yml
@@ -3,6 +3,9 @@ name: python-39
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: ./.github/workflows/sync.yml


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the per-Python-version build workflows. Each one runs sphinx-build / msgfmt against the translated rst files and uploads the rendered HTML as a workflow artifact, with no GitHub API mutation:

- `python-37.yml`, `python-38.yml`, `python-39.yml`, `python-310.yml`, `python-311.yml`, `python-312.yml`, `python-313.yml`, `python-314.yml`, `python-315.yml`

`update-tx-config.yml` is intentionally left implicit; it commits and pushes via `GITHUB_TOKEN`, so the scope is best declared by a maintainer who owns the translation-sync flow.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.